### PR TITLE
팀 삭제 완성

### DIFF
--- a/lib/pages/team/teamDetailPage.dart
+++ b/lib/pages/team/teamDetailPage.dart
@@ -19,13 +19,15 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
     _checkTeamLeader();
   }
 
+// 현재 사용자가 팀 리더인가
   Future<void> _checkTeamLeader() async {
     final teamId = widget.team['teamId'].toString();
-    final result = await TeamService.isTeamLeader(teamId);
+    final result = await TeamService.isTeamLeader(teamId); // teamId 전달
     setState(() {
       isLeader = result;
     });
   }
+
 
   String getEnumLabel<T>(String? enumName, Map<T, String> enumMap) {
     try {
@@ -69,27 +71,34 @@ class _TeamDetailPageState extends State<TeamDetailPage> {
           ),
           IconButton(
             icon: const Icon(Icons.delete),
-            onPressed: () async {
-              final confirm = await showDialog(
-                context: context,
-                builder: (_) => AlertDialog(
-                  title: const Text("삭제 확인"),
-                  content: const Text("정말로 이 팀을 삭제할까요?"),
-                  actions: [
-                    TextButton(
-                        onPressed: () => Navigator.pop(context, false),
-                        child: const Text("취소")),
-                    TextButton(
-                        onPressed: () => Navigator.pop(context, true),
-                        child: const Text("삭제")),
-                  ],
-                ),
-              );
-              if (confirm == true) {
-                await TeamService.deleteTeam(widget.team['teamId'].toString());
-                Navigator.pop(context);
+              onPressed: () async {
+                final confirm = await showDialog<bool>(
+                  context: context,
+                  builder: (context) => AlertDialog(
+                    title: const Text("삭제 확인"),
+                    content: const Text("정말로 이 팀을 삭제할까요?"),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: const Text("취소"),
+                      ),
+                      TextButton(
+                        onPressed: () => Navigator.of(context).pop(true),
+                        child: const Text("삭제"),
+                      ),
+                    ],
+                  ),
+                );
+
+                if (confirm == true) {
+                  await TeamService.deleteTeam(widget.team['teamId'].toString());
+
+                  if (mounted) {
+                    Navigator.pop(context, true);
+                  }
+                }
               }
-            },
+
           ),
         ]
             : null,

--- a/lib/pages/team/teamSearchPage.dart
+++ b/lib/pages/team/teamSearchPage.dart
@@ -190,22 +190,22 @@ class TeamSearchPageState extends State<TeamSearchPage> {
 
                   ),
 
-
-
-
                   title: Text(team['teamName'] ?? '이름 없음'),
                   subtitle: Text(
                     "${getEnumLabel(team['event'], eventEnumMap)} · "
                         "${getEnumLabel(team['region'], regionEnumMap)} · "
                         "${team['memberAge'] ?? '나이 미상'}대",
                   ),
-                  onTap: () {
-                    Navigator.push(
+                  onTap: () async{
+                    final result = await Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder : (_) => TeamDetailPage(team: team),
                         ),
                     );
+                    if(result == true) {
+                      fetchTeams();
+                    }
                   },
                 );
               },

--- a/lib/service/teamService.dart
+++ b/lib/service/teamService.dart
@@ -110,7 +110,7 @@ class TeamService {
     return "http://${ApiConstants.serverUrl}:714$path";
   }
 
-  /// 팀 리더 여부 조회
+  /// 팀 리더 여부 조회 (응답 본문 문자열: "LEADER")
   static Future<bool> isTeamLeader(String teamId) async {
     try {
       final token = await TokenStorage.getAccessToken();
@@ -125,15 +125,17 @@ class TeamService {
       );
 
       if (res.statusCode == 200) {
-        return res.data['isLeader'] == true;
+        return res.data.toString().trim() == "LEADER";
       } else {
         print("리더 여부 조회 실패: ${res.statusCode}");
         return false;
       }
-    } catch(e) {
+    } catch (e) {
       print("에러발생 : $e");
       return false;
     }
   }
+
+
 
 }


### PR DESCRIPTION
feat: 팀 삭제 기능 구현 완료

- 팀 상세 페이지에서 팀 리더만 삭제 가능하도록 버튼 노출
- 삭제 요청 시 확인 다이얼로그 추가
- 삭제 API(`/teams/{id}`) 연동 및 예외 처리
- 삭제 후 목록 화면으로 안전하게 이동
- 삭제 성공/실패 로그 출력 추가
