### PR TITLE
feat : 경기장 기본 ui 만듬

### DIFF
--- a/lib/pages/match/matchpage.dart
+++ b/lib/pages/match/matchpage.dart
@@ -4,6 +4,7 @@ import 'package:project/contants/api_contants.dart';
 import 'package:project/pages/match/fetchMatch.dart';
 import 'package:project/pages/match/matching.dart';
 import 'package:project/pages/match/matching_data.dart';
+import 'package:project/pages/stadium/stadiumSearchPage.dart';
 import 'package:project/utils/token_storage.dart';
 import 'package:project/widgets/matchingCard.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -242,6 +243,19 @@ class _MatchpageState extends State<Matchpage> {
                 ),
               ],
             ),
+            SizedBox(height: 30.0),
+            ElevatedButton(
+                onPressed: ()  {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const StadiumSearchPage()),
+                  );
+            },
+                style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    foregroundColor: Colors.black,
+                ),
+                child: Text("경기장 찾기")),
             SizedBox(height: 10.0),
             ListView.builder(
               shrinkWrap: true,

--- a/lib/pages/stadium/stadiumDetailPage.dart
+++ b/lib/pages/stadium/stadiumDetailPage.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:project/pages/stadium/stadiumFormPage.dart';
+
+class StadiumDetailPage extends StatefulWidget {
+  final Map<String, dynamic> stadium; // 상세 정보를 표시할 경기장 데이터
+  final bool isLeader; // 현재 사용자가 이 경기장의 관리자(리더)인지 여부
+  const StadiumDetailPage({super.key, required this.stadium, this.isLeader = false});
+
+  @override
+  State<StadiumDetailPage> createState() => _StadiumDetailPageState();
+}
+
+class _StadiumDetailPageState extends State<StadiumDetailPage> {
+  // TODO : API를 통해 다시 불러오는 로직이 필요
+  late Map<String, dynamic> _currentStadiumData;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentStadiumData = Map<String, dynamic>.from(widget.stadium);
+  }
+
+  // TODO : 백엔드에서 이미지 가져오는거 수정하면 작업
+  String _getFullStadiumImageUrl(String? path) {
+    if (path == null || path.isEmpty) return "";
+    return "assets/images/butteoLogo.png"; // 임시 이미지
+  }
+
+  void _navigateToEditPage() async {
+    // 수정 페이지로 이동하고, 결과값을 기다립니다.
+    final result = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => StadiumFormPage(initialData: _currentStadiumData),
+      ),
+    );
+
+    // 수정 완료 후 'updated'와 같은 결과가 돌아오면 데이터를 갱신
+    if (result == 'updated') {
+      // TODO: 실제 경기장 ID를 이용하여 최신 데이터 다시 불러오기
+      setState(() {
+        print("경기장 정보가 업데이트됨: 다시 불러오기 필요");
+      });
+      if (mounted) Navigator.pop(context, 'updated');
+    }
+  }
+
+  void _deleteStadium() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text("경기장 삭제"),
+        content: Text("${_currentStadiumData['stadiumName']}을(를) 정말로 삭제하시겠습니까?"),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text("취소"),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text("삭제"),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      // TODO: 경기장 삭제 API 호출
+      print("경기장 삭제 완료: ${_currentStadiumData['stadiumName']}");
+      if (mounted) {
+        Navigator.pop(context, 'deleted'); // 삭제 완료 신호를 이전 페이지로 전달
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final String stadiumName = _currentStadiumData['stadiumName'] ?? '이름 없음';
+    final String price = _currentStadiumData['price']?.toString() ?? '가격 정보 없음';
+    final String location = _currentStadiumData['location'] ?? '위치 정보 없음';
+    final String description = _currentStadiumData['description'] ?? '경기장 설명이 없습니다.';
+    final String stadiumType = _currentStadiumData['stadiumType'] ?? '종류 미지정';
+    final String region = _currentStadiumData['region'] ?? '지역 미지정';
+
+    // 운영 시간 표시 로직
+    String operatingHoursText;
+    if (_currentStadiumData['alwaysOpen'] == true) {
+      operatingHoursText = '상시 운영';
+    } else if (_currentStadiumData['startDate'] != null && _currentStadiumData['endDate'] != null) {
+      operatingHoursText = '${_currentStadiumData['startDate']} ~ ${_currentStadiumData['endDate']}';
+    } else {
+      operatingHoursText = '운영 기간 정보 없음';
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(stadiumName),
+        actions: widget.isLeader
+            ? [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            onPressed: _navigateToEditPage,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            onPressed: _deleteStadium,
+          ),
+        ]
+            : null,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Center(
+              child: CircleAvatar(
+                radius: 60,
+                backgroundColor: Colors.grey.shade300,
+                backgroundImage: _currentStadiumData['imageUrl'] != null && _currentStadiumData['imageUrl'].isNotEmpty
+                    ? NetworkImage(_getFullStadiumImageUrl(_currentStadiumData['imageUrl']))
+                    : null,
+                child: _currentStadiumData['imageUrl'] == null || _currentStadiumData['imageUrl'].isEmpty
+                    ? const Icon(Icons.sports_soccer, size: 50, color: Colors.grey) // 기본 아이콘
+                    : null,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Center(
+              child: Text(
+                stadiumName,
+                style: Theme.of(context).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _buildInfoRow(Icons.monetization_on, '가격', '$price 원'),
+            _buildInfoRow(Icons.location_on, '위치', location),
+            _buildInfoRow(Icons.access_time, '운영 기간', operatingHoursText),
+            _buildInfoRow(Icons.category, '종류', stadiumType),
+            _buildInfoRow(Icons.map, '지역', region),
+            const Divider(height: 32),
+            Text(
+              '경기장 설명',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            // TODO: 여기에 예약, 후기, 사진 갤러리 등의 추가 정보 섹션
+            Center(
+              child: ElevatedButton(
+                onPressed: () {
+                  // TODO: 예약하기 기능 구현
+                  print('예약하기 버튼 클릭');
+                },
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 15),
+                  backgroundColor: Colors.blueAccent,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text(
+                  '예약하기',
+                  style: TextStyle(fontSize: 18, color: Colors.white),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(IconData icon, String title, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: Colors.grey[700], size: 24),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.grey[600]),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  value,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/stadium/stadiumFormPage.dart
+++ b/lib/pages/stadium/stadiumFormPage.dart
@@ -1,0 +1,470 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+// TODO: 실제 프로젝트 경로에 맞게 service 및 enum import 경로 수정
+// import 'package:project/service/stadium_service.dart';
+// import 'package:project/data/stadium_enum.dart';
+
+class StadiumFormPage extends StatefulWidget {
+  final Map<String, dynamic>? initialData; // 수정 모드일 경우 초기 데이터
+  const StadiumFormPage({super.key, this.initialData});
+
+  @override
+  State<StadiumFormPage> createState() => _StadiumFormPageState();
+}
+
+class _StadiumFormPageState extends State<StadiumFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _priceController = TextEditingController();
+  final TextEditingController _locationController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+
+  DateTimeRange? _operatingHours;
+  bool _alwaysOpen = false;
+  String? _stadiumType;
+  String? _region;
+  List<File> _selectedImages = []; // 이미지 파일 목록
+  final ImagePicker _picker = ImagePicker();
+
+  late final bool isEditMode; // 수정 모드인지 확인
+
+  @override
+  void initState() {
+    super.initState();
+    isEditMode = widget.initialData != null;
+
+    if (isEditMode) {
+      _nameController.text = widget.initialData!['stadiumName'] ?? '';
+      _priceController.text = widget.initialData!['price']?.toString() ?? '';
+      _locationController.text = widget.initialData!['location'] ?? '';
+      _descriptionController.text = widget.initialData!['description'] ?? '';
+
+      // TODO: Enum 값 초기화 (실제 enum이 있다면 valueOf 등으로 변환 필요)
+      _stadiumType = widget.initialData!['stadiumType'];
+      _region = widget.initialData!['region'];
+
+      // 운영 시간 초기화 (백엔드 데이터 형식에 따라 다를 수 있음)
+      // 예시: 백엔드에서 start_date, end_date 문자열로 온다고 가정
+      final String? startDateStr = widget.initialData!['startDate'];
+      final String? endDateStr = widget.initialData!['endDate'];
+      if (startDateStr != null && endDateStr != null) {
+        _operatingHours = DateTimeRange(
+          start: DateTime.parse(startDateStr),
+          end: DateTime.parse(endDateStr),
+        );
+      }
+      _alwaysOpen = widget.initialData!['alwaysOpen'] ?? false;
+
+      // 이미지 URL이 있다면 File 객체로 변환하거나, NetworkImage로 표시 준비
+      // 여기서는 예시로 초기 이미지 URL만 표시하고, 실제 파일은 선택 시에만 처리
+      // 만약 기존 이미지를 수정할 수 있게 하려면 더 복잡한 로직이 필요합니다.
+      // _selectedImages에 기존 이미지 파일이 있다면 여기에 로드해야 합니다.
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _priceController.dispose();
+    _locationController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  // --- 이미지 관련 로직 ---
+  Future<void> _pickImage() async {
+    final List<XFile>? pickedFiles = await _picker.pickMultiImage();
+
+    if (pickedFiles != null && pickedFiles.isNotEmpty) {
+      setState(() {
+        List<File> newImages = [..._selectedImages];
+        for (var xfile in pickedFiles) {
+          newImages.add(File(xfile.path));
+          if (newImages.length >= 6) {
+            break;
+          }
+        }
+        _selectedImages = newImages;
+      });
+    }
+  }
+
+  void _removeImage(int index) {
+    setState(() {
+      _selectedImages.removeAt(index);
+    });
+  }
+  // --- 이미지 관련 로직 끝 ---
+
+  // --- 운영 시간 관련 로직 ---
+  Future<void> _selectOperatingHours(BuildContext context) async {
+    final DateTimeRange? picked = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(DateTime.now().year - 1),
+      lastDate: DateTime(DateTime.now().year + 5),
+      initialDateRange: _operatingHours,
+      helpText: '운영 시작일과 종료일 선택',
+      cancelText: '취소',
+      confirmText: '확인',
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData.light().copyWith(
+            primaryColor: Colors.lightGreen,
+            colorScheme: const ColorScheme.light(primary: Colors.lightGreen),
+            buttonTheme: const ButtonThemeData(textTheme: ButtonTextTheme.primary),
+          ),
+          child: child!,
+        );
+      },
+    );
+    if (picked != null && picked != _operatingHours) {
+      setState(() {
+        _operatingHours = picked;
+        _alwaysOpen = false; // 날짜 범위 선택 시 상시 운영 해제
+      });
+    }
+  }
+  // --- 운영 시간 관련 로직 끝 ---
+
+  void _submitForm() {
+    if (_formKey.currentState!.validate()) {
+      // TODO: 백엔드 API 호출 로직 구현 (StadiumService 사용)
+      if (isEditMode) {
+        print('경기장 수정 요청 전송!');
+        // StadiumService.updateStadium(...)
+        // Navigator.pop(context, 'updated'); // 수정 완료 후 이전 페이지로 결과 전달
+      } else {
+        print('경기장 등록 요청 전송!');
+        // StadiumService.createStadium(...)
+        // Navigator.pop(context, 'created'); // 생성 완료 후 이전 페이지로 결과 전달
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(isEditMode ? '경기장 수정 요청 전송!' : '경기장 등록 요청 전송!')),
+      );
+      // 실제 API 호출 후 성공 여부에 따라 Navigator.pop 호출
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditMode ? '경기장 정보 수정' : '경기장 관리자 등록'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              Text(
+                isEditMode ? '경기장 정보 수정' : '경기장 등록',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+
+              // 이미지 업로드 섹션
+              GestureDetector(
+                onTap: _pickImage,
+                child: Container(
+                  height: 120,
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade200,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.grey.shade400),
+                  ),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.image_outlined, size: 40, color: Colors.grey),
+                      const SizedBox(height: 8),
+                      Text(
+                        '사진을 등록해주세요 (${_selectedImages.length}/6)',
+                        style: const TextStyle(color: Colors.grey),
+                      ),
+                      const Text(
+                        '최대 6장까지 가능합니다.',
+                        style: TextStyle(color: Colors.grey, fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              if (_selectedImages.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '선택된 이미지 (${_selectedImages.length}/6)',
+                    style: TextStyle(fontWeight: FontWeight.bold, color: Colors.grey[700]),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  height: 80,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: _selectedImages.length,
+                    itemBuilder: (context, index) {
+                      return Padding(
+                        padding: const EdgeInsets.only(right: 8.0),
+                        child: Stack(
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Image.file(
+                                _selectedImages[index],
+                                width: 80,
+                                height: 80,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                            Positioned(
+                              right: 0,
+                              top: 0,
+                              child: GestureDetector(
+                                onTap: () => _removeImage(index),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: Colors.black54,
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                  child: const Icon(Icons.close, color: Colors.white, size: 18),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+              const SizedBox(height: 24),
+
+              // 경기장 이름
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: '경기장 이름 *',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '경기장 이름을 입력해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 가격
+              TextFormField(
+                controller: _priceController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(
+                  labelText: '시간 당 가격 *',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '가격을 입력해주세요.';
+                  }
+                  if (double.tryParse(value) == null) {
+                    return '유효한 숫자를 입력해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 위치
+              TextFormField(
+                controller: _locationController,
+                decoration: InputDecoration(
+                  labelText: '위치 *',
+                  border: const OutlineInputBorder(),
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.location_on),
+                    onPressed: () {
+                      // TODO: 위치 선택기(지도) 기능 구현
+                      print('위치 아이콘 클릭됨');
+                    },
+                  ),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '위치를 입력해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 운영기간 섹션
+              InkWell(
+                onTap: _alwaysOpen ? null : () => _selectOperatingHours(context),
+                child: InputDecorator(
+                  decoration: const InputDecoration(
+                    labelText: '운영기간 *',
+                    border: OutlineInputBorder(),
+                    contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: <Widget>[
+                      Text(
+                        _operatingHours == null
+                            ? '선택해주세요'
+                            : '${_operatingHours!.start.toLocal().toString().split(' ')[0]} ~ ${_operatingHours!.end.toLocal().toString().split(' ')[0]}',
+                        style: TextStyle(
+                          color: _alwaysOpen ? Colors.grey : null,
+                        ),
+                      ),
+                      Icon(Icons.calendar_today, color: _alwaysOpen ? Colors.grey : null),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Switch(
+                    value: _alwaysOpen,
+                    onChanged: (bool value) {
+                      setState(() {
+                        _alwaysOpen = value;
+                        if (value) {
+                          _operatingHours = null; // 상시 운영 시 날짜 범위 초기화
+                        }
+                      });
+                    },
+                    activeColor: Colors.lightGreen,
+                  ),
+                  const SizedBox(width: 8),
+                  const Expanded(
+                    child: Text(
+                      '종료일 없음 (상시 운영)',
+                      style: TextStyle(fontSize: 14),
+                    ),
+                  ),
+                ],
+              ),
+              if (_alwaysOpen)
+                const Padding(
+                  padding: EdgeInsets.only(left: 40.0, top: 4.0),
+                  child: Text(
+                    '상시 운영으로 변경시, 다른 기본 운영기간은 삭제됩니다.',
+                    style: TextStyle(color: Colors.redAccent, fontSize: 12),
+                  ),
+                ),
+              const SizedBox(height: 16),
+
+              // 경기장 종류 드롭다운
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(
+                  labelText: '경기장 종류 *',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+                value: _stadiumType,
+                isExpanded: true,
+                items: <String>['풋살장', '축구장', '농구장', '테니스장'] // 예시 데이터
+                    .map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                  );
+                }).toList(),
+                onChanged: (String? newValue) {
+                  setState(() {
+                    _stadiumType = newValue;
+                  });
+                },
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '경기장 종류를 선택해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 지역 드롭다운
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(
+                  labelText: '지역 *',
+                  border: OutlineInputBorder(),
+                  contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+                value: _region,
+                isExpanded: true,
+                items: const ['서울', '부산', '대구', '인천', '광주', '대전', '울산', '세종', '경기', '강원', '충북', '충남', '전북', '전남', '경북', '경남', '제주'] // 예시 데이터
+                    .map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value),
+                  );
+                }).toList(),
+                onChanged: (String? newValue) {
+                  setState(() {
+                    _region = newValue;
+                  });
+                },
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return '지역을 선택해주세요.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // 경기장 설명 필드
+              TextFormField(
+                controller: _descriptionController,
+                maxLines: 5,
+                decoration: const InputDecoration(
+                  labelText: '경기장 설명',
+                  hintText: '경기장 정보에 추가하실 내용을 작성해주세요.',
+                  border: OutlineInputBorder(),
+                  alignLabelWithHint: true,
+                  contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+                ),
+              ),
+              const SizedBox(height: 32),
+
+              // 경기장 등록/수정 버튼
+              ElevatedButton(
+                onPressed: _submitForm,
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  backgroundColor: Colors.orange,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: Text(
+                  isEditMode ? '경기장 정보 수정' : '경기장 등록',
+                  style: const TextStyle(fontSize: 18, color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/stadium/stadiumSearchPage.dart
+++ b/lib/pages/stadium/stadiumSearchPage.dart
@@ -1,0 +1,299 @@
+import 'package:flutter/material.dart';
+import 'package:project/pages/stadium/stadiumFormPage.dart';
+import 'package:project/pages/stadium/stadiumDetailPage.dart';
+
+class StadiumSearchPage extends StatefulWidget {
+  const StadiumSearchPage({super.key});
+
+  @override
+  State<StadiumSearchPage> createState() => _StadiumSearchPageState();
+}
+
+class _StadiumSearchPageState extends State<StadiumSearchPage> {
+  String selectedRegion = "전체";
+  String selectedStadiumType = "전체";
+  List<dynamic> allStadiums = []; // 전체 경기장 목록
+  List<dynamic> filteredStadiums = []; // 필터링된 경기장 목록
+  bool isLoading = false;
+
+  final List<String> regions = ['전체', '서울', '경기', '강원', '충청', '전라', '경상', '제주'];
+  final List<String> stadiumTypes = ['전체', '풋살장', '축구장', '농구장', '테니스장'];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchStadiums();
+  }
+
+  Future<void> _fetchStadiums() async {
+    if (mounted) {
+      setState(() => isLoading = true);
+    }
+    try {
+      // TODO: 실제 StadiumService.fetchStadiums() 호출로 대체
+      // final result = await StadiumService.fetchStadiums();
+      // allStadiums = result;
+      // 임시 데이터
+      allStadiums = [
+        {
+          'id': '1',
+          'stadiumName': '우리동네 풋살장',
+          'price': 30000,
+          'location': '서울 강남구 역삼동',
+          'stadiumType': '풋살장',
+          'region': '서울',
+          'imageUrl': 'stadium1.jpg',
+          'startDate': '2024-01-01',
+          'endDate': '2024-12-31',
+          'alwaysOpen': false,
+          'description': '도심 속 쾌적한 풋살장입니다. 주차 가능.'
+        },
+        {
+          'id': '2',
+          'stadiumName': '용산 농구 코트',
+          'price': 20000,
+          'location': '서울 용산구 이태원동',
+          'stadiumType': '농구장',
+          'region': '서울',
+          'imageUrl': 'stadium2.jpg',
+          'alwaysOpen': true,
+          'description': '야외 농구 코트. 조명 시설 완비.'
+        },
+        {
+          'id': '3',
+          'stadiumName': '부산 해운대 테니스장',
+          'price': 25000,
+          'location': '부산 해운대구',
+          'stadiumType': '테니스장',
+          'region': '부산',
+          'imageUrl': 'stadium3.jpg',
+          'startDate': '2025-03-01',
+          'endDate': '2025-11-30',
+          'alwaysOpen': false,
+          'description': '바다를 보며 테니스를 칠 수 있는 아름다운 테니스장.'
+        },
+        {
+          'id': '4',
+          'stadiumName': '대구 달서구 축구장',
+          'price': 40000,
+          'location': '대구 달서구',
+          'stadiumType': '축구장',
+          'region': '대구',
+          'imageUrl': 'stadium4.jpg',
+          'alwaysOpen': false,
+          'startDate': '2025-01-01',
+          'endDate': '2025-12-31',
+          'description': '잔디 상태 최상의 축구장.'
+        },
+      ];
+      _applyFilters();
+    } catch (e) {
+      print("경기장 조회 실패: $e");
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("경기장 목록을 불러오는데 실패했습니다: $e")),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => isLoading = false);
+      }
+    }
+  }
+
+  void _applyFilters() {
+    setState(() {
+      filteredStadiums = allStadiums.where((stadium) {
+        final regionMatch = selectedRegion == "전체" || stadium['region'] == selectedRegion;
+        final typeMatch = selectedStadiumType == "전체" || stadium['stadiumType'] == selectedStadiumType;
+        return regionMatch && typeMatch;
+      }).toList();
+    });
+  }
+
+  // 경기장 이미지 URL을 구성하는 헬퍼 함수 (StadiumService에서 가져올 수 있음)
+  String _getFullStadiumImageUrl(String? path) {
+    if (path == null || path.isEmpty) return "";
+    return "assets/images/butteoLogo.png";//임시
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('전체 경기장'),
+        centerTitle: true,
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Divider(height: 5),
+
+          //지역필터
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: regions.map((region) {
+                final isSelected = region == selectedRegion;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                  child: ChoiceChip(
+                    label: Text(region),
+                    selected: isSelected,
+                    onSelected: (_) {
+                      setState(() => selectedRegion = region);
+                      _applyFilters();
+                    },
+                    selectedColor: Colors.grey[700],
+                    labelStyle: TextStyle(color: isSelected ? Colors.white : Colors.black),
+                    side: BorderSide(color: isSelected ? Colors.grey[700]! : Colors.grey.shade400),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+          const SizedBox(height: 10),
+          // 구장 타입 필터
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              children: stadiumTypes.map((type) {
+                final isSelected = type == selectedStadiumType;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                  child: ChoiceChip(
+                    label: Text(type),
+                    selected: isSelected,
+                    onSelected: (_) {
+                      setState(() => selectedStadiumType = type);
+                      _applyFilters();
+                    },
+                    selectedColor: Colors.grey[700],
+                    labelStyle: TextStyle(color: isSelected ? Colors.white : Colors.black),
+                    side: BorderSide(color: isSelected ? Colors.grey[700]! : Colors.grey.shade400),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("검색 결과 (${filteredStadiums.length}개)", style: Theme.of(context).textTheme.titleMedium),
+                ElevatedButton.icon(
+                  onPressed: () async {
+                    // 경기장 등록 페이지로 이동
+                    final result = await Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => const StadiumFormPage()),
+                    );
+                    // 등록 또는 수정 후 돌아왔을 때 목록 갱신
+                    if (result == 'created' || result == 'updated' || result == 'deleted') {
+                      _fetchStadiums();
+                    }
+                  },
+                  icon: const Icon(Icons.add, color: Colors.white),
+                  label: const Text('경기장 등록', style: TextStyle(color: Colors.white)),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blueGrey,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : filteredStadiums.isEmpty
+                ? const Center(child: Text("검색된 경기장이 없습니다."))
+                : ListView.builder(
+              itemCount: filteredStadiums.length,
+              itemBuilder: (context, index) {
+                final stadium = filteredStadiums[index];
+                // 경기장 이미지 URL (임시)
+                final String imageUrl = _getFullStadiumImageUrl(stadium['imageUrl']);
+
+                return Card(
+                  margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  elevation: 2,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                  child: InkWell(
+                    onTap: () async {
+                      final result = await Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => StadiumDetailPage(
+                            stadium: stadium,
+                            isLeader: index == 0, // 첫 번째 경기장은 리더로 가정
+                          ),
+                        ),
+                      );
+                      // 상세 페이지에서 수정/삭제 후 돌아왔을 때 목록 갱신
+                      if (result == 'updated' || result == 'deleted') {
+                        _fetchStadiums();
+                      }
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Row(
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: Image.network(
+                              imageUrl,
+                              width: 80,
+                              height: 80,
+                              fit: BoxFit.cover,
+                              errorBuilder: (context, error, stackTrace) =>
+                                  Container(
+                                    width: 80,
+                                    height: 80,
+                                    color: Colors.grey.shade300,
+                                    child: const Icon(Icons.broken_image, color: Colors.grey),
+                                  ),
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  stadium['stadiumName'] ?? '이름 없음',
+                                  style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '${stadium['region'] ?? ''} | ${stadium['stadiumType'] ?? ''}',
+                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.grey[700]),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  '가격: ${stadium['price']?.toString() ?? '정보 없음'} 원',
+                                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/service/stdiumService.dart
+++ b/lib/service/stdiumService.dart
@@ -1,0 +1,12 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+
+class StadiumService {
+  static final Dio _dio = Dio();
+
+  //경기장 등록
+  static Future<String?> createStadium({
+    required FormData formData
+}) async {
+  }
+}


### PR DESCRIPTION
### ✨ feat: 경기장 관련 UI 페이지 추가
- [x] 경기장 등록 페이지 추가 (lib/pages/stadium/stadiumFormPage.dart)
- [x] 경기장 상세 보기 페이지 추가 (lib/pages/stadium/stadiumDetailPage.dart)
- [x] 경기장 목록 및 필터 페이지 추가 (lib/pages/stadium/stadiumSearchPage.dart)
- [x] 지역 및 경기장 유형 필터 기능 구현
- [x] 이미지 없는 경우 회색 박스 + 아이콘으로 기본 처리

### 🔧 현재 상태  
- UI는 정상 작동 중이며 전체 구조 완성
- 백엔드에서 이미지 업로드 및 조회 기능이 미구현되어 `imageUrl` 연동은 보류
- 관련 구조는 미리 구현 완료 → 추후 백엔드 연동 시 즉시 연결 가능

### 💡 참고 자료 또는 스크린샷 (옵션)
<img width="425" alt="스크린샷 2025-05-28 오후 3 00 40" src="https://github.com/user-attachments/assets/4c05d847-6b4b-48ce-90a6-61ea2414ca26" />

